### PR TITLE
Add a way to claim airships that weren't claimed before (i.e. old versions)

### DIFF
--- a/src/main/java/ValkyrienWarfareBase/Command/AirshipSettingsCommand.java
+++ b/src/main/java/ValkyrienWarfareBase/Command/AirshipSettingsCommand.java
@@ -27,6 +27,7 @@ public static final ArrayList<String> completionOptions = new ArrayList<String>(
 	static {
 		completionOptions.add("transfer");
 		completionOptions.add("allowPlayer");
+		completionOptions.add("claim");
 	}
 
 	@Override
@@ -109,8 +110,17 @@ public static final ArrayList<String> completionOptions = new ArrayList<String>(
 				}
 			}
 		} else {
+			if (wrapper.wrapping.creator == null || wrapper.wrapping.creator.trim().isEmpty())	{
+				if (args.length == 1 && args[0].equals("claim"))	{
+					wrapper.wrapping.creator = p.entityUniqueID.toString();
+					p.addChatMessage(new TextComponentString("You've successfully claimed an airship!"));
+					return;
+				}
+			}
 			p.addChatMessage(new TextComponentString("You need to be the owner of an airship to change airship settings!"));
 		}
+		
+		sender.addChatMessage(new TextComponentString(TextFormatting.RED + "Usage: " + getCommandUsage(sender)));
 	}
 	
 	@Override

--- a/src/main/java/ValkyrienWarfareBase/EventsCommon.java
+++ b/src/main/java/ValkyrienWarfareBase/EventsCommon.java
@@ -391,7 +391,7 @@ public class EventsCommon {
 			PhysicsWrapperEntity physObj = ValkyrienWarfareMod.physicsManager.getObjectManagingPos(event.getWorld(), event.getPos());
 			if (physObj != null)	{
 				if (!(physObj.wrapping.creator.equals(event.getEntityPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getEntityPlayer().entityUniqueID.toString())))	{
-					event.getEntityPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!"));
+					event.getEntityPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!" + (physObj.wrapping.creator == null || physObj.wrapping.creator.trim().isEmpty() ? " Try using \"/airshipSettings claim\"!" : "")));
 					event.setCanceled(true);
 					return;
 				}
@@ -405,7 +405,7 @@ public class EventsCommon {
 			PhysicsWrapperEntity physObj = ValkyrienWarfareMod.physicsManager.getObjectManagingPos(event.getWorld(), event.getPos());
 			if (physObj != null)	{
 				if (!(physObj.wrapping.creator.equals(event.getPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getPlayer().entityUniqueID.toString())))	{
-					event.getPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!"));
+					event.getPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!" + (physObj.wrapping.creator == null || physObj.wrapping.creator.trim().isEmpty() ? " Try using \"/airshipSettings claim\"!" : "")));
 					event.setCanceled(true);
 					return;
 				}


### PR DESCRIPTION
This should fixed the issue described [here](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2761225-valkyrien-warfare-airships-physics-subworlds-and?comment=314).